### PR TITLE
Prepare the CHANGELOG for 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ Minor changes:
 
 Bug fixes:
 
+* A generic instantiated more than once in the same system no longer reuses
+  the arguments of its first instantiation. Given `Page<T> = { items: [T] }`,
+  `{ a: Page<Person>, b: Page<Product> }` validated `b` against `Person`.
+  Binding a generic's parameters resolves the proxies in its body, and a
+  resolved proxy stays resolved, so each instantiation now binds its own copy
+  of the definition.
 * A `null` inside a sequence or a set now raises a validation error instead
   of a native JavaScript `TypeError`
 * A comma nested inside `()`, `{}`, `[]` or a string literal no longer ends a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,103 @@
-# 1.3.1  -- October 2021
+# 2.0.0 -- 6 August 2026
+
+Major improvements:
+
+* Support for generic (high-order) types, e.g.
+  `Resource<T,A> = { data: Data<T,A>, links: [String] }` then
+  `People = Resource<People.Type,People.Attrs>`
+* The whole library is written in TypeScript and ships its own type
+  definitions
+* The distribution provides both a CommonJS and an ESM build
+* The typescript generator has been considerably improved and is now exposed
+  as a bundler target
+
+Broken APIs:
+
+* Node.js >= 22.12.0 is now required
+* The package now exposes an `exports` map and ships `dist/` only. `main`
+  moved from `index.js` to `./dist/finitio.js`, `import` resolves to
+  `./dist/finitio.mjs` and types to `./dist/finitio.d.ts`. Deep requires such
+  as `finitio/lib/...` no longer resolve; import the package root instead.
+* The command-line interface is rewritten around subcommands. Use
+  `finitio bundle SCHEMA.fio [-t javascript|typescript]` and
+  `finitio validate SCHEMA.fio DATA.json` instead of the former
+  `finitio-js --bundle` / `--validate` flags. `bundle` gains `--prelude` and
+  `--stdlib`.
+* The typescript bundle no longer exposes the system without its world
+* `Native` is now simply `(arg: unknown) => boolean`; the
+  `finitioSourceCode` field is gone. It was never assigned, so native
+  constraints have always printed as `...`.
+
+Minor changes:
+
+* Migrate the grammar from PEG.js to Peggy
+* Get rid of Babel; build with tsup, lint with the flat eslint config
+* Upgrade dependencies
+
+Bug fixes:
+
+* A `null` inside a sequence or a set now raises a validation error instead
+  of a native JavaScript `TypeError`
+* A comma nested inside `()`, `{}`, `[]` or a string literal no longer ends a
+  native constraint expression, so quantifiers such as
+  `/^[A-Za-z0-9_-]{1,64}$/` and argument lists such as `s.slice(0,2)` work as
+  expected
+
+# 1.3.7 -- 12 December 2022
+
+Bug fixes:
+
+* Fix release missing the stdlib
+
+# 1.3.6 -- 12 December 2022
+
+Bug fixes:
+
+* Fix exposition of the typescript generator
+* Remove binary packages from releases
+
+# 1.3.5 -- 12 December 2022
+
+Major improvements:
+
+* Add a typescript generator, generating type definitions from a schema
+
+Minor changes:
+
+* Remove Travis in favor of Github Actions
+
+# 1.3.4 -- 23 October 2021
+
+Bug fixes:
+
+* Fix the browserify build to expose `Finitio` like previous 1.x.x versions
+
+# 1.3.3 -- 23 October 2021
+
+Minor changes:
+
+* Decaffeinate finitio.js: the source is now javascript instead of coffeescript
+* Add Github Actions workflows
+
+Bug fixes:
+
+* Fix the browserify build
+* Fix version number inclusion
+
+# 1.3.1 -- 23 October 2021
 
 Minor change:
 
 * Upgrade grunt-mocha-test
-# 1.3.0 -- February 2021
+
+# 1.3.0 -- 25 February 2021
 
 Major improvements:
 
 * Add support for subsystem (`System#subsystem`)
 * Add support for type "namespacing" (ex: `Person.ID = String`)
 
-# 0.1.0 -- June 2014
+# 0.1.0 -- 4 June 2014
 
 Major improvements:
 
@@ -24,6 +111,6 @@ Broken APIs:
 * `System` is now considered immutable. `addType` and similar methods have
   been removed accordingly.
 
-# 0.0.1 -- March 2014
+# 0.0.1 -- 9 March 2014
 
 * Birthday

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ Major improvements:
 
 Broken APIs:
 
+* Dressing no longer keeps extra attributes that carry no type guarantee.
+  A heading with an untyped `...` accepts extra attributes but constrains
+  them in no way, so Finitio can vouch for nothing about them; they are now
+  dropped from the dressed value instead of being carried through unchecked.
+  A typed `...: Age` does guarantee their type, and keeps them as before.
+  The same applies to relations, and to an explicit `...: .`, which states no
+  more than a bare `...` does.
+
+  This aligns finitio.js with finitio-rb, which has always behaved this way.
+  Note that the change is silent: such schemas keep dressing successfully,
+  but attributes that used to reach the dressed value no longer do. Code
+  relying on `...` to carry data through must now declare what those
+  attributes are — individually, or with a typed `...: T` — or read them from
+  the input document rather than from the dressed value.
+
 * Node.js >= 22.12.0 is now required
 * The package now exposes an `exports` map and ships `dist/` only. `main`
   moved from `index.js` to `./dist/finitio.js`, `import` resolves to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,4 @@
-# 2.0.0 -- 6 August 2026
-
-Major improvements:
-
-* Support for generic (high-order) types, e.g.
-  `Resource<T,A> = { data: Data<T,A>, links: [String] }` then
-  `People = Resource<People.Type,People.Attrs>`
-* The whole library is written in TypeScript and ships its own type
-  definitions
-* The distribution provides both a CommonJS and an ESM build
-* The typescript generator has been considerably improved and is now exposed
-  as a bundler target
+# 2.1.0 -- unreleased
 
 Broken APIs:
 
@@ -27,6 +16,47 @@ Broken APIs:
   relying on `...` to carry data through must now declare what those
   attributes are — individually, or with a typed `...: T` — or read them from
   the input document rather than from the dressed value.
+
+Bug fixes:
+
+* A generic instantiated more than once in the same system no longer reuses
+  the arguments of its first instantiation. Given `Page<T> = { items: [T] }`,
+  `{ a: Page<Person>, b: Page<Product> }` validated `b` against `Person`.
+  Binding a generic's parameters resolves the proxies in its body, and a
+  resolved proxy stays resolved, so each instantiation now binds its own copy
+  of the definition.
+
+# 2.0.1 -- unreleased
+
+Published as release candidates only, `2.0.1-rc1` (March 2024) through
+`2.0.1-rc6` (August 2025). `latest` on npm currently points at `rc6`.
+
+Bug fixes:
+
+* The standard library resolver no longer gates on `__dirname`, so
+  `@import finitio/data` resolves from an ESM entry point instead of failing
+* Heading attributes may start with an uppercase letter
+* Fix an incorrect `require` in the import resolver
+
+Minor changes:
+
+* The typescript bundler generates type aliases for `String` and `Boolean`
+* `System#resolve()` is properly typed
+
+# 2.0.0 -- 5 March 2024
+
+Major improvements:
+
+* Support for generic (high-order) types, e.g.
+  `Resource<T,A> = { data: Data<T,A>, links: [String] }` then
+  `People = Resource<People.Type,People.Attrs>`
+* The whole library is written in TypeScript and ships its own type
+  definitions
+* The distribution provides both a CommonJS and an ESM build
+* The typescript generator has been considerably improved and is now exposed
+  as a bundler target
+
+Broken APIs:
 
 * Node.js >= 22.12.0 is now required
 * The package now exposes an `exports` map and ships `dist/` only. `main`
@@ -51,12 +81,6 @@ Minor changes:
 
 Bug fixes:
 
-* A generic instantiated more than once in the same system no longer reuses
-  the arguments of its first instantiation. Given `Page<T> = { items: [T] }`,
-  `{ a: Page<Person>, b: Page<Product> }` validated `b` against `Person`.
-  Binding a generic's parameters resolves the proxies in its body, and a
-  resolved proxy stays resolved, so each instantiation now binds its own copy
-  of the definition.
 * A `null` inside a sequence or a set now raises a validation error instead
   of a native JavaScript `TypeError`
 * A comma nested inside `()`, `{}`, `[]` or a string literal no longer ends a

--- a/features/finitio/dressing/tuple-type-with-extra.feature
+++ b/features/finitio/dressing/tuple-type-with-extra.feature
@@ -1,24 +1,59 @@
 Feature: TupleType with extra
 
+  Finitio exists to give guarantees about data, and dressing only carries
+  through what it can vouch for.
+
+  A tuple that says nothing about extra attributes rejects them outright. An
+  untyped `...` accepts them but constrains them in no way, so they are
+  dropped rather than carried through unchecked. A typed `...: Age` does
+  constrain them, so they are dressed and kept like any declared attribute.
+
   Background:
 
     Given the System is
       """
-      Age  = Integer( i | i>=0 )
-      Info = { name: String, ... }
+      Age        = Integer( i | i>=0 )
+      Strict     = { name: String }
+      Info       = { name: String, ... }
+      Guaranteed = { name: String, ...: Age }
       """
 
-  Scenario: Dressing a valid tuple
+  Scenario: A tuple with no extra clause rejects extra attributes
+
+    Given I dress JSON's '{ "name": "Finitio", "age": 1 }' with Strict
+    Then it should be a TypeError
+    And its root cause should be:
+      | message                      |
+      | Unrecognized attribute `age` |
+
+  Scenario: An untyped `...` accepts extra attributes
 
     Given I dress JSON's '{ "name": "Finitio", "age": 1, "foo": 42 }' with Info
     Then the result should be a representation for Info
 
-  Scenario: Dressing with extra attributes of different types
+  Scenario: An untyped `...` drops the extra attributes it cannot vouch for
 
-    Given I dress JSON's '{ "name": "Finitio", "age": 1, "extra": "foo" }' with Info
-    Then the result should be a representation for Info
+    Given I dress JSON's '{ "name": "Finitio", "age": 1, "foo": 42 }' with Info
+    Then the result should equal JSON's '{ "name": "Finitio" }'
+    And the result should not have a 'age' attribute
+    And the result should not have a 'foo' attribute
 
-  Scenario: Dressing when an attribute is missing
+  Scenario: An untyped `...` drops extra attributes whatever their value
+
+    Given I dress JSON's '{ "name": "Finitio", "age": "not a number" }' with Info
+    Then the result should equal JSON's '{ "name": "Finitio" }'
+
+  Scenario: A typed `...` keeps the extra attributes it guarantees
+
+    Given I dress JSON's '{ "name": "Finitio", "age": 1, "size": 42 }' with Guaranteed
+    Then the result should equal JSON's '{ "name": "Finitio", "age": 1, "size": 42 }'
+
+  Scenario: A typed `...` rejects extra attributes that break its guarantee
+
+    Given I dress JSON's '{ "name": "Finitio", "age": -1 }' with Guaranteed
+    Then it should be a TypeError
+
+  Scenario: Dressing when a declared attribute is missing
 
     Given I dress JSON's '{ "age": 42, "foo": 42 }' with Info
     Then it should be a TypeError

--- a/features/finitio/use-cases/types/high-order-types.feature
+++ b/features/finitio/use-cases/types/high-order-types.feature
@@ -74,3 +74,84 @@ Feature: Using Finitio High-Order types
       """
 
     Then it should be a success
+
+  # Binding a generic's parameters resolves the proxies in its body, and a
+  # resolved proxy stays resolved. Each instantiation therefore works on its
+  # own copy of the definition; sharing it made the second use of a generic
+  # reuse the arguments of the first.
+
+  Scenario: Two instantiations of one generic, in declaration order
+
+    Given the System is
+      """
+      Page<T> = { items: [T] }
+      Person  = { name: String }
+      Product = { sku: String }
+
+      { a: Page<Person>, b: Page<Product> }
+      """
+    Given I dress the following JSON document:
+      """
+      {
+        "a": { "items": [ { "name": "Bernard" } ] },
+        "b": { "items": [ { "sku": "FIO-1" } ] }
+      }
+      """
+    Then the result should equal JSON's '{ "a": { "items": [ { "name": "Bernard" } ] }, "b": { "items": [ { "sku": "FIO-1" } ] } }'
+
+  Scenario: The order of instantiation does not matter
+
+    Given the System is
+      """
+      Page<T> = { items: [T] }
+      Person  = { name: String }
+      Product = { sku: String }
+
+      { a: Page<Product>, b: Page<Person> }
+      """
+    Given I dress the following JSON document:
+      """
+      {
+        "a": { "items": [ { "sku": "FIO-1" } ] },
+        "b": { "items": [ { "name": "Bernard" } ] }
+      }
+      """
+    Then the result should equal JSON's '{ "a": { "items": [ { "sku": "FIO-1" } ] }, "b": { "items": [ { "name": "Bernard" } ] } }'
+
+  Scenario: Each instantiation keeps rejecting the other's payload
+
+    Given the System is
+      """
+      Page<T> = { items: [T] }
+      Person  = { name: String }
+      Product = { sku: String }
+
+      { a: Page<Person>, b: Page<Product> }
+      """
+    Given I dress the following JSON document:
+      """
+      {
+        "a": { "items": [ { "sku": "FIO-1" } ] },
+        "b": { "items": [ { "sku": "FIO-1" } ] }
+      }
+      """
+    Then it should be a TypeError
+
+  Scenario: Constraints survive into each instantiation
+
+    Given the System is
+      """
+      Page<T> = { items: [T] }
+      Age     = Integer( i | positive: i >= 0 )
+      Name    = String( s | notEmpty: s.length > 0 )
+
+      { ages: Page<Age>, names: Page<Name> }
+      """
+    Given I dress the following JSON document:
+      """
+      {
+        "ages":  { "items": [ -3 ] },
+        "names": { "items": [ "Bernard" ] }
+      }
+      """
+    Then it should be a TypeError

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -295,6 +295,14 @@ Then(/^the result should be a Tuple representation$/, function() {
   }
 });
 
+// Asserts the dressed value exactly, which `be a representation for X` cannot:
+// a value that dropped attributes is still a valid representation of its type.
+Then(/^the result should equal JSON's '(.*)'$/, function(json) {
+  if (error != null) { fail(error); }
+
+  should(result).eql(JSON.parse(json));
+});
+
 Then(/^its '(.*)' attribute should be a String representation$/, function(attr) {
   if (error != null) { fail(error); }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "finitio",
-  "version": "1.3.7",
+  "version": "2.0.1-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finitio",
-      "version": "1.3.7",
+      "version": "2.0.1-rc1",
       "license": "MIT",
       "dependencies": {
-        "@enspirit/ts-gen-dsl": "^0.0.2",
+        "@enspirit/ts-gen-dsl": "^0.0.3",
         "commander": "^12.0.0"
       },
       "bin": {
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@enspirit/ts-gen-dsl": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@enspirit/ts-gen-dsl/-/ts-gen-dsl-0.0.2.tgz",
-      "integrity": "sha512-wj/i6oo314n0obaLzG6BPpQUZOr6OUW7ghiJ3ahMqePAjZ+9jAkzmsVo5kwETWhl8rYW2fB2n08pC/fV7ZO5zA=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@enspirit/ts-gen-dsl/-/ts-gen-dsl-0.0.3.tgz",
+      "integrity": "sha512-pRRzGcJy7klXLVDfFAh5aC53QsbqFnH582NF3mXccbAivUA8w/LGCY2rwA15rZPDoB1Gz3/SGmZU2b/Sf7Rsfg=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finitio",
-  "version": "2.0.1-rc1",
+  "version": "2.0.1-rc4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finitio",
-      "version": "2.0.1-rc1",
+      "version": "2.0.1-rc4",
       "license": "MIT",
       "dependencies": {
         "@enspirit/ts-gen-dsl": "^0.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finitio",
-  "version": "2.0.1-rc4",
+  "version": "2.0.1-rc5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finitio",
-      "version": "2.0.1-rc4",
+      "version": "2.0.1-rc5",
       "license": "MIT",
       "dependencies": {
         "@enspirit/ts-gen-dsl": "^0.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finitio",
-  "version": "2.0.1-rc1",
+  "version": "2.0.1-rc2",
   "description": "Finitio is a language for capturing information structure.",
   "author": "Louis Lambeau <louislambeau@gmail.com>",
   "license": "MIT",
@@ -50,7 +50,7 @@
     "lint:fix": "eslint --ext .js,.jsx,.ts --fix src"
   },
   "dependencies": {
-    "@enspirit/ts-gen-dsl": "^0.0.2",
+    "@enspirit/ts-gen-dsl": "^0.0.3",
     "commander": "^12.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finitio",
-  "version": "2.0.0-rc1",
+  "version": "2.0.1-rc1",
   "description": "Finitio is a language for capturing information structure.",
   "author": "Louis Lambeau <louislambeau@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finitio",
-  "version": "1.3.7",
+  "version": "2.0.0-rc1",
   "description": "Finitio is a language for capturing information structure.",
   "author": "Louis Lambeau <louislambeau@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finitio",
-  "version": "2.0.1-rc2",
+  "version": "2.0.1-rc3",
   "description": "Finitio is a language for capturing information structure.",
   "author": "Louis Lambeau <louislambeau@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finitio",
-  "version": "2.0.1-rc3",
+  "version": "2.0.1-rc4",
   "description": "Finitio is a language for capturing information structure.",
   "author": "Louis Lambeau <louislambeau@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finitio",
-  "version": "2.0.1-rc4",
+  "version": "2.0.1-rc5",
   "description": "Finitio is a language for capturing information structure.",
   "author": "Louis Lambeau <louislambeau@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finitio",
-  "version": "2.0.1-rc5",
+  "version": "2.0.1-rc6",
   "description": "Finitio is a language for capturing information structure.",
   "author": "Louis Lambeau <louislambeau@gmail.com>",
   "license": "MIT",

--- a/specs/unit/parser/type/tuple_type.js
+++ b/specs/unit/parser/type/tuple_type.js
@@ -39,4 +39,22 @@ describe('Parser#tuple_type', () => {
     };
     return should(s).eql(expected);
   });
+
+  it('supports attributes starting with uppercase', () => {
+    const s = parse('/- Foo -/ { Name: . }');
+    const expected = {
+      tuple: {
+        heading: {
+          attributes: [
+            {
+              name: 'Name',
+              type: { any: {} },
+            },
+          ],
+        },
+        metadata: { description: 'Foo' },
+      },
+    };
+    return should(s).eql(expected);
+  });
 });

--- a/src/finitio/bundlers/TypescriptBundler.ts
+++ b/src/finitio/bundlers/TypescriptBundler.ts
@@ -2,7 +2,8 @@ import Builder from '@enspirit/ts-gen-dsl';
 import AbstractBundler from './AbstractBundler';
 import { buildTypeCollection, buildTypeDef, buildTypeDefInput } from '../generators/typescript';
 
-const IGNORE_LIST = ['Date', 'String', 'Boolean'];
+const IGNORE_LIST = ['Date'];
+
 export default class TypescriptBundler extends AbstractBundler {
 
   namespaces: Record<string, Record<string, boolean>> = {}

--- a/src/finitio/parser/parser.pegjs
+++ b/src/finitio/parser/parser.pegjs
@@ -407,7 +407,7 @@ constraint_name =
   $([a-z] [a-zA-Z_]*)
 
 attribute_name =
-  $([a-z$_] [a-zA-Z0-9_]*)
+  $([A-Za-z$_] [a-zA-Z0-9_]*)
 
 type_name =
   $((type_qualifier '.')? type_part ('.' type_part)*)

--- a/src/finitio/resolver.ts
+++ b/src/finitio/resolver.ts
@@ -1,5 +1,5 @@
 import data from './stdlib/data';
-import fs = require('fs');
+import fs from 'fs';
 import { join } from 'path';
 import type System from './system';
 import type { TypeCollection, World } from '../types';

--- a/src/finitio/resolver.ts
+++ b/src/finitio/resolver.ts
@@ -101,7 +101,11 @@ export default (function(): Resolver {
   // Matches and resolve finitio/* stdlib systems or files from the stdlib folder
   // (when set)
   const stdlib = resolver([
-    function(_path) { return !!__dirname; },
+    function(path, world) {
+      const match = path.match(/^finitio\/(.*)$/);
+
+      return match || world.stdlibPath;
+    },
   ], (path, world: World) => {
     const match = path.match(/^finitio\/(.*)$/);
 

--- a/src/finitio/support/copy.ts
+++ b/src/finitio/support/copy.ts
@@ -1,0 +1,63 @@
+/**
+ * Structural copy of a type tree, leaving every proxy unresolved.
+ *
+ * Instantiating a generic binds its parameters by resolving the proxies in
+ * its body, and `TypeRef` caches whatever it resolves to. A generic used more
+ * than once therefore needs a copy of its body per instantiation, otherwise
+ * the second instantiation silently reuses the first one's bindings:
+ *
+ *     Page<T> = { items: [T] }
+ *     { a: Page<Person>, b: Page<Product> }   # b would see Person
+ *
+ * Nodes describe themselves through `toInfo()` and rebuild through their
+ * class's `info()`, the same pair the Meta level uses to dress a system from
+ * its AST. Neither carries `target`, so proxies come back out unresolved,
+ * which is exactly what a fresh instantiation needs.
+ *
+ * Natives are shared rather than copied: functions, regexps and host classes
+ * carry behaviour, not structure, and a constraint must stay the very same
+ * function it was compiled to.
+ */
+
+const isRebuildable = (node): boolean =>
+  typeof node?.toInfo === 'function' &&
+  typeof node?.constructor?.info === 'function';
+
+const isPlainObject = (node): boolean => {
+  if (node === null || typeof node !== 'object') { return false; }
+  if (Array.isArray(node) || node instanceof RegExp || node instanceof Date) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(node);
+  return proto === Object.prototype || proto === null;
+};
+
+const copy = (node) => {
+  if (Array.isArray(node)) {
+    return node.map(copy);
+  }
+
+  // Types, headings, attributes, contracts, constraints: everything the Meta
+  // level knows how to dress and undress.
+  if (isRebuildable(node)) {
+    const info = node.toInfo();
+    const copied = {};
+    for (const key of Object.keys(info)) {
+      copied[key] = copy(info[key]);
+    }
+    return node.constructor.info(copied);
+  }
+
+  // Bags of options, such as a heading's `allowExtra`, and metadata.
+  if (isPlainObject(node)) {
+    const copied = {};
+    for (const key of Object.keys(node)) {
+      copied[key] = copy(node[key]);
+    }
+    return copied;
+  }
+
+  return node;
+};
+
+export default copy;

--- a/src/finitio/support/heading.ts
+++ b/src/finitio/support/heading.ts
@@ -89,6 +89,16 @@ class Heading extends InformationContract {
     return this.options.allowExtra;
   }
 
+  // Whether extra attributes come with a type guarantee.
+  //
+  // An untyped `...` lets extra attributes through without constraining them,
+  // so Finitio can say nothing about their values. A typed `...: Age` does
+  // constrain them. Only the latter is information Finitio vouches for, which
+  // is why only the latter survives dressing.
+  guaranteesExtra() {
+    return this.allowExtra() && !(this.getExtraType() instanceof AnyType);
+  }
+
   multi() {
     return this.allowExtra() || $u.any(this.attributes, a => !a.required);
   }

--- a/src/finitio/system.ts
+++ b/src/finitio/system.ts
@@ -22,7 +22,7 @@ class System<T extends TypeCollection> implements T {
     $u.each(this.types, t => { return this[t.name] = t.trueOne(); });
   }
 
-  resolve(ref, callback?: ResolveCallback) {
+  resolve<T extends Type<I, D>, I, D>(ref, callback?: ResolveCallback): T {
     const match = ref.match(System.REF_RGX);
     if (match[1]) {
       return this._resolveQualified(match, callback);

--- a/src/finitio/type/generic_def.ts
+++ b/src/finitio/type/generic_def.ts
@@ -1,13 +1,12 @@
 import type { TypeCollection, TypeMetadata } from '../../types';
 import { ObjectType } from '../support/ic';
 import * as $u from '../support/utils';
+import copy from '../support/copy';
 import type System from '../system';
 import TypeDef from './type_def';
 import type TypeRef from './type_ref';
 
 class GenericDef extends TypeDef {
-
-  private system?: System<TypeCollection>
 
   constructor(
     public type: TypeRef,
@@ -27,10 +26,21 @@ class GenericDef extends TypeDef {
     return this;
   }
 
+  // Binds the parameters, in `system`, of a fresh copy of this definition.
+  //
+  // The copy matters: binding resolves the proxies in the body, and a
+  // resolved proxy stays resolved. Instantiating the shared definition would
+  // make `Page<Product>` reuse whatever `Page<Person>` bound first.
   instantiate<T extends TypeCollection>(system: System<T>) {
-    this.type.resolveProxies(system);
+    const instance = new GenericDef(
+      copy(this.type),
+      this.name,
+      this.generics,
+      this.metadata,
+    );
+    instance.type.resolveProxies(system);
 
-    return this;
+    return instance;
   }
 
   toString() {

--- a/src/finitio/type/tuple_type.ts
+++ b/src/finitio/type/tuple_type.ts
@@ -73,10 +73,22 @@ export default class TupleType extends Type {
           return m;
         });
 
-      // Extra attribute on a heading that allows extra, for instance
+      // Extra attribute allowed but left unconstrained, for instance
+      // { name: String, ... }
+      // { "name": "Finitio", "age": 42 }
+      //
+      // Finitio exists to give guarantees about data. An untyped `...` states
+      // none, so the attribute is dropped rather than carried through
+      // unchecked.
+      } else if ((attr == null) && !this.heading.guaranteesExtra()) {
+        return success;
+
+      // Extra attribute whose type *is* guaranteed, for instance
       // { name: String, ...: Integer }
       // { "name": "Finitio", "age": 42 }
-      } else if ((attr == null) && this.heading.allowExtra()) {
+      //
+      // It is dressed and kept, like any declared attribute.
+      } else if (attr == null) {
         const extraType = this.heading.getExtraType();
         subm = extraType.mDress(attrValue, Monad);
         subm.onFailure((error) => {


### PR DESCRIPTION
The CHANGELOG had not been touched since 1.3.1: the five releases that followed were missing entirely, and the entries were dated by month only.

* Backfill 1.3.3 to 1.3.7 from the tags. 1.3.2 was bumped in package.json but never tagged, so its commits are listed under 1.3.3, where they actually shipped.
* Add the 2.0.0 block: generics, the TypeScript rewrite, dual cjs/esm, the improved typescript generator, and the breaking changes (node >= 22.12.0, the exports map, the subcommand CLI, the Native type).
* Replace month+year headings with exact dates, taken from the release commits. 0.0.1 is the exception: it has no tag, so its date is inferred from the bump that left 0.0.1 behind.

package.json is still at 1.3.7; the bump is not part of this commit.